### PR TITLE
Fix socket buffer sizes for FreeBSD

### DIFF
--- a/conn/conn_freebsd.go
+++ b/conn/conn_freebsd.go
@@ -14,9 +14,13 @@ func setFwmark(fd, fwmark int) error {
 }
 
 func (lso ListenerSocketOptions) buildSetFns() setFuncSlice {
+	// a buffer size(1 MiB) that fits nicely with the default limit of the sysctl
+	// option kern.ipc.maxsockbuf(2 MiB) in FreeBSD
+	const bufSize = 1 << 20
+
 	return setFuncSlice{}.
-		appendSetSendBufferSize(lso.SendBufferSize).
-		appendSetRecvBufferSize(lso.ReceiveBufferSize).
+		appendSetSendBufferSize(bufSize).
+		appendSetRecvBufferSize(bufSize).
 		appendSetFwmarkFunc(lso.Fwmark).
 		appendSetTrafficClassFunc(lso.TrafficClass).
 		appendSetPMTUDFunc(lso.PathMTUDiscovery)


### PR DESCRIPTION
Because:
The old used limit(7 MiB) was too large for the default maximum limit (2 MiB) kern.ipc.maxsockbuf of FreeBSD.

I built swgp-go under FreeBSD and tried to run it with a client configuration. I ran into the following error:
> ERR Failed to start service client=client err="listen udp 127.0.0.1:20220: failed to set socket option SO_SNDBUF: no buffer space available"
Theoretically it's possible to increase the sysctl option sysctl kern.ipc.maxsockbuf to something higher than 7 MiB(like 8 MiB) and the error will vanish, however this solution might not be so obvious for end users.

I saw that the buffer size was defined here https://github.com/database64128/swgp-go/blob/464f4dd467527a05a8a908be96f2a76b37a2726f/conn/conn.go#L117 the same for all platforms. While it worked flawlessly with Linux, it was much larger than the maximum size set in any default installation of FreeBSD.

This PR adjusts the limit only for FreeBSD. I had to override the size in the FreeBSD-specific file conn/conn_freebsd.go since the limit is set globally in conn/conn.go for all platforms.