### PR TITLE
Fix address resolution for FreeBSD

### DIFF
--- a/conn/addr.go
+++ b/conn/addr.go
@@ -130,7 +130,10 @@ func ResolveIP(ctx context.Context, network, host string) (netip.Addr, error) {
 	if err != nil {
 		return netip.Addr{}, err
 	}
-	return ips[0], nil
+	// FreeBSD always returns IPv4 addresses as IPv4-mapped IPv6 addresses, even
+	// if network is "ip4". Pure IPv4 and IPv6 addresses won't be affected by
+	// unmapping.
+	return ips[0].Unmap(), nil
 }
 
 // ResolveIP returns the IP address itself or the resolved IP address of the domain name.


### PR DESCRIPTION
Because:
On FreeBSD the resolver always by default returns IPv4-mapped IPv6 addresses for IPv4 addresses.

When I try to run swgp-go under FreeBSD with a client configuration, I get many warning messages of the form:
> WRN Failed to write swgpPacket to proxyConn client=client listenAddress=127.0.0.1:20220 clientAddress=127.0.0.1:45272 proxyConnListenAddress=0.0.0.0:48509 proxyAddress=[::ffff:1.2.3.4]:20221 swgpPacketLength=209 segmentSize=209 err="write udp4 0.0.0.0:48509->[::ffff:1.2.3.4]:20221: address ::ffff:192.168.0.162: non-IPv4 address"
Notice how the IPv4 address 1.2.3.4 was mapped into an IPv6 address with a "4In6" form. This causes the failure to send packets to the uplink proxy.

This PR makes sure any IPv4-mapped IPv6 addresses are unmapped back to their IPv4 form so that it may be used for sending packets later.